### PR TITLE
Idkwhattonamethis

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -41,6 +41,7 @@ typedef enum e_type
 	TRUNC,
 	CREAT,
 	HIN,
+	TOKEN,
 	UNKNOWN
 }		t_type;
 
@@ -140,6 +141,7 @@ char			*replace_exitstatus(char *s);
 int				check_redirections(t_token_list *head);
 char			*find_env_var_value(t_data *data, char *name);
 int				quote_count(char *s, char c);
+void			set_token_type(t_token_list *head);
 
 /* utils lexer */
 void			remove_token_node(t_token_list *head, t_token_list **node);

--- a/src/parser.c
+++ b/src/parser.c
@@ -114,6 +114,7 @@ char	*msh_parser(t_data *data)
 {
 	char	*command;
 
+	set_token_type(data->tokens);
 	if (check_tokens_via_type(data) != 0)
 		return (NULL);
 	if (get_command_types(data) != 0)

--- a/src/utils_parser.c
+++ b/src/utils_parser.c
@@ -1,5 +1,18 @@
 #include "../include/minishell.h"
 
+void	set_token_type(t_token_list *head)
+{
+	t_token_list	*current;
+
+	current = head;
+	while (current != NULL)
+	{
+		if (current->type == HEREDOC)
+			current->next->type = TOKEN;
+		current = current->next;
+	}
+}
+
 /**
  * 	@brief	gets size for allocating command string
  * 	@param	tokens: linked list from lexer

--- a/src/utils_parser_dquote.c
+++ b/src/utils_parser_dquote.c
@@ -45,6 +45,11 @@ static int	remove_quotes(char *old, char *new)
 		i++;
 		j++;
 	}
+	if (quote_count(new, '\'') % 2 != 0)
+	{
+		ft_parse_error("odd amount of single quotes", NULL);
+		return (EXIT_FAILURE);
+	}
 	return (EXIT_SUCCESS);
 }
 
@@ -88,7 +93,10 @@ static char	*handle_quotes(char *s)
 		return (ft_parse_error("odd amount of double quotes", NULL));
 	}
 	if (remove_quotes(s, out) != 0)
+	{
+		free(out);
 		return (NULL);
+	}
 	return (out);
 }
 

--- a/src/utils_parser_types.c
+++ b/src/utils_parser_types.c
@@ -35,6 +35,32 @@ int	type_redirec(char *s)
 	return (EXIT_FAILURE);
 }
 
+static int	remove_quotes(char *old, char *new)
+{
+	int	i;
+	int	j;
+
+	i = 0;
+	j = 0;
+	while (old[i])
+	{
+		while (old[i] == '\'')
+			i++;
+		if (old[i] == '|')
+			new[j] = 26;
+		else
+			new[j] = old[i];
+		i++;
+		j++;
+	}
+	if (quote_count(new, '"') % 2 != 0)
+	{
+		ft_parse_error("odd amount of double quotes", NULL);
+		return (EXIT_FAILURE);
+	}
+	return (EXIT_SUCCESS);
+}
+
 /**
  * 	@brief	removes single quotes
  * 	@param	pointer to literal token string of type SQUOTE
@@ -43,8 +69,6 @@ int	type_redirec(char *s)
 char	*type_squote(char **s)
 {
 	char	*out;
-	int		i;
-	int		j;
 
 	if (quote_count(*s, '\'') % 2 != 0)
 	{
@@ -54,16 +78,10 @@ char	*type_squote(char **s)
 	out = ft_calloc(ft_strlen(*s) + 1, sizeof(char));
 	if (out == NULL)
 		ft_error(strerror(errno));
-	i = 0;
-	j = 1;
-	while (s[0][j] != 39 && s[0][j])
+	if (remove_quotes(*s, out) != 0)
 	{
-		if (s[0][j] == '|')
-			out[i] = 26;
-		else
-			out[i] = s[0][j];
-		i++;
-		j++;
+		free(*s);
+		return (NULL);
 	}
 	free(*s);
 	return (out);


### PR DESCRIPTION
In der funktion pipe_exec in Zeile 169 in der Funktion ft_one bleibt das Programm bei
`cat < file1 | grep hello`
in cat hängen. Mit lldb kann ich zwar in ft_one reingehen aber es bleibt dann nie hängen, weshalb ich davon ausgehe, dass es der child process sein muss. Ich vermute stark dass man in dem cat prompt drinnen ist, da es auch mit ls z.B. funktioniert 
`cat < file1 | ls`
Warum das beim ersten mal nicht funktioniert aber die anderen male doch könnte mit den file descriptoren zusammenhängen. Vermutlich passiert irgendwas ungewolltes zwischen der redirection und der Pipe. Ich bin aber viel zu durch um mich da jetzt noch reinzuarbeiten.

Könnt natürlich aber auch an was ganz anderem liegen.